### PR TITLE
修复单聊渲染消息的bug

### DIFF
--- a/app/view/chat/main.html
+++ b/app/view/chat/main.html
@@ -12,7 +12,7 @@
                  -->
                 <!--单聊且是他发的item.userid=msgcontext.dstid && 发给我的 item.dstid=myid 或者是我item.userid= myid发的,&&发给他的item.dstid= msgcontext.dstid 我发给他的  -->
                 <li class="chat " :class="item.ismine?'mine':'other'" v-for="item in msglist"
-                    v-if="item.msg.cmd==msgcontext.cmd && (( item.msg.cmd==10 &&  (item.ismine? item.msg.dstid==msgcontext.dstid : item.msg.dstid==msgcontext.userid )) || ( item.msg.cmd==11 &&  (item.msg.dstid==msgcontext.dstid))) ">
+                    v-if="item.msg.cmd==msgcontext.cmd && (( item.msg.cmd==10 &&  (item.ismine? item.msg.dstid==msgcontext.dstid : item.msg.userid==msgcontext.dstid )) || ( item.msg.cmd==11 &&  (item.msg.dstid==msgcontext.dstid))) ">
 
                     <div>
                         <img class="avatar" :src="item.user.avatar ||'/asset/images/avatar0.png'"/>


### PR DESCRIPTION
**问题描述**

现有用户A，B和C，每个用户互相添加了另外两个用户。当A发送消息给B时，B会渲染出A和C发送同一条消息给B。发现是 app/view/chat/main.html 文件中，对单聊消息渲染的判断条件出了问题。

**原判断条件**

```html
item.ismine? item.msg.dstid==msgcontext.dstid : item.msg.dstid==msgcontext.userid
```

如果消息是我发的 (`ismine` 为真)，那么消息的目标 `dstid` 必须等于当前聊天上下文 `msgcontext.dstid`；如果消息不是我发的，那么消息的目标 `dstid` 必须等于我的用户 ID `userid`。

这个逻辑的问题在于，对于我收到的消息，只检查了消息是否发送给我，但没有检查消息的发送者是否是当前的聊天对象。因此会出现B看到A发送的消息同时渲染在了A和C里面的问题。

**修改后判断条件**

```html
item.ismine? item.msg.dstid==msgcontext.dstid : item.msg.userid==msgcontext.dstid
```

如果消息不是我发的，那么消息的发送者 `userid` 必须等于当前聊天上下文 `dstid`。

那为什么原判断条件不需要了呢？

```html
item.msg.dstid==msgcontext.userid
```

服务端分配消息时，已经根据消息的dstid，分配到该用户的管道中，因此，用户收到的消息一定是满足该条件的（前提是：消息不是我发的 (`ismine` 为假)）。